### PR TITLE
FIX: Reference to seo.css file

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -3,4 +3,4 @@ Name: seo cms config
 ---
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_css:
-    - resources/cyber-duck/silverstripe-seo/assets/css/seo.css
+    - cyber-duck/silverstripe-seo:assets/css/seo.css


### PR DESCRIPTION
This appeared as an error in the backend with 4.1 until I applied this fix.