### PR TITLE
FIX #28 Use vendor/module:path to access module's CSS

### DIFF
--- a/_config/cms.yml
+++ b/_config/cms.yml
@@ -3,4 +3,4 @@ Name: seo cms config
 ---
 SilverStripe\Admin\LeftAndMain:
   extra_requirements_css:
-    - resources/vendor/cyber-duck/silverstripe-seo/assets/css/seo.css
+    - cyber-duck/silverstripe-seo:assets/css/seo.css


### PR DESCRIPTION
Use vendor/module:file to link module's seo.css file from Silverstripe controlled resources folder (overridable via a setting in composer.json extras) instead of having a hardcoded path.