### PR TITLE
Change all Varchar(512) to Text

### DIFF
--- a/src/Model/Extension/SeoExtension.php
+++ b/src/Model/Extension/SeoExtension.php
@@ -25,9 +25,9 @@ class SeoExtension extends SeoPageExtension
      * @config array $db 
      **/
     private static $db = [
-        'Title'           => 'Varchar(512)',
-        'URLSegment'      => 'Varchar(512)',
-        'MetaDescription' => 'Varchar(512)'
+        'Title'           => 'MediumText',
+        'URLSegment'      => 'MediumText',
+        'MetaDescription' => 'MediumText'
     ];
 
     /**

--- a/src/Model/Extension/SeoExtension.php
+++ b/src/Model/Extension/SeoExtension.php
@@ -25,9 +25,9 @@ class SeoExtension extends SeoPageExtension
      * @config array $db 
      **/
     private static $db = [
-        'Title'           => 'MediumText',
-        'URLSegment'      => 'MediumText',
-        'MetaDescription' => 'MediumText'
+        'Title'           => 'Text',
+        'URLSegment'      => 'Text',
+        'MetaDescription' => 'Text'
     ];
 
     /**

--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -74,8 +74,8 @@ class SeoPageExtension extends DataExtension
      * @config array $db
      **/
     private static $db = [
-        'MetaTitle'       => 'MediumText',
-        'Canonical'       => 'MediumText',
+        'MetaTitle'       => 'Text',
+        'Canonical'       => 'Text',
         'Robots'          => 'Varchar(100)',
         'Priority'        => 'Decimal(3,2)',
         'ChangeFrequency' => 'Varchar(20)',

--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -74,8 +74,8 @@ class SeoPageExtension extends DataExtension
      * @config array $db
      **/
     private static $db = [
-        'MetaTitle'       => 'Varchar(512)',
-        'Canonical'       => 'Varchar(512)',
+        'MetaTitle'       => 'MediumText',
+        'Canonical'       => 'MediumText',
         'Robots'          => 'Varchar(100)',
         'Priority'        => 'Decimal(3,2)',
         'ChangeFrequency' => 'Varchar(20)',

--- a/src/Model/Extension/SeoSiteConfigExtension.php
+++ b/src/Model/Extension/SeoSiteConfigExtension.php
@@ -31,12 +31,12 @@ class SeoSiteConfigExtension extends DataExtension
      * @config array $db 
      **/
     private static $db = [
-        'OGSiteName'             => 'Varchar(512)',
-        'TwitterHandle'          => 'Varchar(512)',
-        'CreatorTwitterHandle'   => 'Varchar(512)',
-        'FacebookAppID'          => 'Varchar(512)',
+        'OGSiteName'             => 'MediumText',
+        'TwitterHandle'          => 'MediumText',
+        'CreatorTwitterHandle'   => 'MediumText',
+        'FacebookAppID'          => 'MediumText',
         'UseTitleAsMetaTitle'    => 'Boolean',
-        'SchemaOrganisationName' => 'Varchar(512)'
+        'SchemaOrganisationName' => 'MediumText'
     ];
 
     /**

--- a/src/Model/Extension/SeoSiteConfigExtension.php
+++ b/src/Model/Extension/SeoSiteConfigExtension.php
@@ -31,12 +31,12 @@ class SeoSiteConfigExtension extends DataExtension
      * @config array $db 
      **/
     private static $db = [
-        'OGSiteName'             => 'MediumText',
-        'TwitterHandle'          => 'MediumText',
-        'CreatorTwitterHandle'   => 'MediumText',
-        'FacebookAppID'          => 'MediumText',
+        'OGSiteName'             => 'Text',
+        'TwitterHandle'          => 'Text',
+        'CreatorTwitterHandle'   => 'Text',
+        'FacebookAppID'          => 'Text',
         'UseTitleAsMetaTitle'    => 'Boolean',
-        'SchemaOrganisationName' => 'MediumText'
+        'SchemaOrganisationName' => 'Text'
     ];
 
     /**

--- a/src/Model/SeoHeadTag.php
+++ b/src/Model/SeoHeadTag.php
@@ -37,9 +37,9 @@ class SeoHeadTag extends DataObject
      * @config array $db 
      **/
     private static $db = [
-        'Title' => 'MediumText',
-        'Value' => 'MediumText',
-        'Type'  => 'MediumText'
+        'Title' => 'Text',
+        'Value' => 'Text',
+        'Type'  => 'Text'
     ];
 
     /**

--- a/src/Model/SeoHeadTag.php
+++ b/src/Model/SeoHeadTag.php
@@ -37,9 +37,9 @@ class SeoHeadTag extends DataObject
      * @config array $db 
      **/
     private static $db = [
-        'Title' => 'Varchar(512)',
-        'Value' => 'Varchar(512)',
-        'Type'  => 'Varchar(512)'
+        'Title' => 'MediumText',
+        'Value' => 'MediumText',
+        'Type'  => 'MediumText'
     ];
 
     /**


### PR DESCRIPTION
Hi,

I sometimes have customers having "Row size too large." issues.
The reason is that normally an InnoDB row can only be 8126 bytes.
Varchar columns are stored in the row, Text columns are stored external with a pointer to that in the row, so they take a lot less space in the row. And that solves this issue.

Especially because this module uses multiple varchar(512) this module will trigger the error fast..

This will fix #23 too.