### PR TITLE
Fix for #35: Avoid calling remove() on owner class if method does not…

### DIFF
--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -254,7 +254,7 @@ class SeoPageExtension extends DataExtension
     public function updateSummaryFields(&$fields)
     {
         if(Controller::curr() instanceof SEOAdmin) {
-            Config::inst()->remove($this->owner->class, 'summary_fields');
+            if(method_exists($this->owner->class, 'remove')) Config::inst()->remove($this->owner->class, 'summary_fields');
             Config::modify()->set($this->owner->class, 'summary_fields', $this->getSummaryFields());
 
             $fields = Config::inst()->get($this->owner->class, 'summary_fields');

--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -254,7 +254,7 @@ class SeoPageExtension extends DataExtension
     public function updateSummaryFields(&$fields)
     {
         if(Controller::curr() instanceof SEOAdmin) {
-            if(method_exists($this->owner->class, 'remove')) Config::inst()->remove($this->owner->class, 'summary_fields');
+            if($this->owner->class && method_exists($this->owner->class, 'remove')) Config::inst()->remove($this->owner->class, 'summary_fields');
             Config::modify()->set($this->owner->class, 'summary_fields', $this->getSummaryFields());
 
             $fields = Config::inst()->get($this->owner->class, 'summary_fields');


### PR DESCRIPTION
… exist

We need to check if method exists on owner class - otherwise we will get an "Call to undefined method" error.

Exact error description: "Call to undefined method SilverStripe\Config\Collections\CachedConfigCollection::remove()"

See issue #35 for detailed description and history of that bug