### PR TITLE
Prevent removing summary fields if not set

### DIFF
--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -262,7 +262,10 @@ class SeoPageExtension extends DataExtension
     public function updateSummaryFields(&$fields)
     {
         if(Controller::curr() instanceof SEOAdmin) {
-            Config::inst()->remove($this->owner->class, 'summary_fields');
+            if ($this->owner->config()->get('summary_fields')) {
+                $this->owner->config()->remove('summary_fields');
+            }
+            
             Config::modify()->set($this->owner->class, 'summary_fields', $this->getSummaryFields());
 
             $fields = Config::inst()->get($this->owner->class, 'summary_fields');


### PR DESCRIPTION
- Prevent removing summary_fields without checking if it exists first