### PR TITLE
fix: Change `getPageURL` to use AbsoluteLink on page

### DIFF
--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -496,15 +496,11 @@ class SeoPageExtension extends DataExtension
     }
 
     /**
-     * Get the current page URL // todo getAbsoluteURL()?
-     *
-     * @since version 2.0.0
-     *
      * @return string
-     **/
+     */
     public function getPageURL()
     {
-        return Director::absoluteBaseURL().substr($this->owner->Link(), 1);
+        return $this->owner->getAbsoluteLiveLink(false);
     }
 
     /**


### PR DESCRIPTION
`AbsoluteLink` supports the `alternateAbsoluteLink` hook for extensions such as Subsites and Static Publisher to modify the domain name.