### PR TITLE
ENH setPaginationTags should redirect ?start=0 not 404

### DIFF
--- a/src/Model/Extension/SeoPageExtension.php
+++ b/src/Model/Extension/SeoPageExtension.php
@@ -715,14 +715,14 @@ class SeoPageExtension extends DataExtension
      * @param PaginatedList $list   Paginated list object
      * @param array         $params Array of $_GET params to allow in the URL // todo
      *
-     * @return string|404 response
+     * @return string|404|301 response
      **/
     public function setPaginationTags(PaginatedList $list, $params = []) // @todo allowed
     {
         $controller = Controller::curr();
         if($controller->getRequest()->getVar($list->getPaginationGetVar()) !== NULL) {
             if((int) $list->getPageStart() === 0) {
-                return $controller->httpError(404);
+				return $controller->redirect($controller->getRequest()->getUrl(), 301);
             }
             if($list->CurrentPage() > $list->TotalPages()){
                 return $controller->httpError(404);


### PR DESCRIPTION
Given ?start=0 should always be the first page, I think it's better UX to redirect to the parameterless URL rather than showing a 404 page.